### PR TITLE
PR: from feature/julia to aramco -Bugfix(app-engine): correct TrafficSplit allocations field type from Str…

### DIFF
--- a/src/spaceone/inventory/model/app_engine/service/data.py
+++ b/src/spaceone/inventory/model/app_engine/service/data.py
@@ -1,7 +1,7 @@
 import logging
 
 from schematics import Model
-from schematics.types import DictType, ListType, ModelType, StringType
+from schematics.types import DictType, FloatType, ListType, ModelType, StringType
 
 from spaceone.inventory.libs.schema.cloud_service import BaseResource
 
@@ -11,7 +11,7 @@ _LOGGER = logging.getLogger(__name__)
 class TrafficSplit(Model):
     """AppEngine Traffic Split 모델"""
 
-    allocations = DictType(StringType, serialize_when_none=False)
+    allocations = DictType(FloatType, serialize_when_none=False)
     shard_by = StringType(deserialize_from="shardBy", serialize_when_none=False)
 
 


### PR DESCRIPTION
…ingType to FloatType

- Change allocations field from DictType(StringType) to DictType(FloatType)
- Fix 'Couldnt interpret 0.1 as string' error in traffic split data
- Add FloatType import to support numeric traffic allocation values
- Traffic allocations are float values (0.0-1.0) representing traffic percentages

Resolves: TrafficSplit serialization error with numeric allocation values

### Category
- [ ] New feature
- [ v] Bug fix
- [ ] Improvement
- [ ] Refactor
- [ ] etc

### Description

### Known issue