### PR TITLE
PR: from feature/batch to aramco

### DIFF
--- a/src/spaceone/inventory/model/batch/job/data.py
+++ b/src/spaceone/inventory/model/batch/job/data.py
@@ -108,7 +108,7 @@ job_overview_meta = ItemDynamicLayout.set_fields(
     fields=[
         TextDyField.data_source("Job Name", "data.display_name"),
         TextDyField.data_source("Job ID", "data.uid"),
-        TextDyField.data_source("Full Path", "data.name"),
+        TextDyField.data_source("Full Name", "data.name"),
         EnumDyField.data_source(
             "Status",
             "data.state",


### PR DESCRIPTION
Fix: Change field name from 'Full Path' to 'Full Name'

 - What: Changed the display label for the job name field from "Full Path" to "Full Name".
- Why: The original label "Full Path" was an inaccurate description for the job's 'name' attribute. "Full Name" provides better clarity for users viewing job details.
 - Impact: This change affects the Job Overview card in the Batch service, improving UI text.