### PR TITLE
PR: from Feature/cylim to aramco / Bugfix-Firestore,Datastore

### DIFF
--- a/src/spaceone/inventory/conf/cloud_service_conf.py
+++ b/src/spaceone/inventory/conf/cloud_service_conf.py
@@ -286,7 +286,15 @@ CLOUD_LOGGING_RESOURCE_TYPE_MAP = {
         "Database": {
             "resource_type": "firestore_database",
             "labels_key": "resource.labels.database_id",
-        }
+        },
+        "BackupSchedule": {
+            "resource_type": "firestore_backup_schedule",
+            "labels_key": "resource.labels.backup_schedule_id",
+        },
+        "Backup": {
+            "resource_type": "firestore_backup",
+            "labels_key": "resource.labels.backup_id",
+        },
     },
     "KMS": {
         "KeyRing": {

--- a/src/spaceone/inventory/manager/datastore/namespace_manager.py
+++ b/src/spaceone/inventory/manager/datastore/namespace_manager.py
@@ -67,6 +67,9 @@ class DatastoreNamespaceManager(GoogleCloudManager):
                     namespace.update(
                         {
                             "project": project_id,
+                            "google_cloud_logging": self.set_google_cloud_logging(
+                                "Datastore", "Namespace", project_id, namespace_id
+                            ),
                         }
                     )
                     namespace_data = DatastoreNamespaceData(namespace, strict=False)

--- a/src/spaceone/inventory/manager/firestore/backup_manager.py
+++ b/src/spaceone/inventory/manager/firestore/backup_manager.py
@@ -72,6 +72,9 @@ class FirestoreBackupManager(GoogleCloudManager):
                             "full_name": backup_name,
                             "database_id": backup_database_id,
                             "project": project_id,
+                            "google_cloud_logging": self.set_google_cloud_logging(
+                                "Firestore", "Backup", project_id, backup_id
+                            ),
                         }
                     )
                     backup_data = Backup(backup, strict=False)

--- a/src/spaceone/inventory/manager/firestore/backup_schedule_manager.py
+++ b/src/spaceone/inventory/manager/firestore/backup_schedule_manager.py
@@ -143,6 +143,12 @@ class FirestoreBackupScheduleManager(GoogleCloudManager):
                             "project": project_id,
                             "recurrence_type": recurrence_info["type"],
                             "weekly_day": recurrence_info.get("weekly_day", ""),
+                            "google_cloud_logging": self.set_google_cloud_logging(
+                                "Firestore",
+                                "BackupSchedule",
+                                project_id,
+                                backup_schedule_id,
+                            ),
                         }
                     )
 

--- a/src/spaceone/inventory/manager/firestore/index_manager.py
+++ b/src/spaceone/inventory/manager/firestore/index_manager.py
@@ -126,12 +126,9 @@ class FirestoreIndexManager(GoogleCloudManager):
 
                     # Exclude fields that start with __
                     original_fields = index.get("fields", [])
-                    filtered_fields = FirestoreIndex.filter_internal_fields(
-                        original_fields
-                    )
 
                     # If no fields after filtering, exclude the index
-                    if not filtered_fields:
+                    if not original_fields:
                         continue
 
                     # Extract collection group
@@ -143,7 +140,7 @@ class FirestoreIndexManager(GoogleCloudManager):
 
                     # Convert fields to string summary
                     field_strings = []
-                    for field in filtered_fields:
+                    for field in original_fields:
                         field_path = field.get("fieldPath", "")
                         order = field.get("order", "")
                         if field_path:

--- a/src/spaceone/inventory/model/firestore/index/data.py
+++ b/src/spaceone/inventory/model/firestore/index/data.py
@@ -22,13 +22,3 @@ class FirestoreIndex(BaseResource):
             "resource_id": f"https://firestore.googleapis.com/v1/{self.full_name}",
             "external_link": f"https://console.cloud.google.com/firestore/databases/{self.database_id}/indexes?project={self.project}",
         }
-
-    @staticmethod
-    def filter_internal_fields(fields):
-        """GCP internal fields (__로 시작하는 필드) 제거"""
-        filtered_fields = []
-        for field in fields:
-            field_path = field.get("fieldPath", "")
-            if not field_path.startswith("__"):
-                filtered_fields.append(field)
-        return filtered_fields


### PR DESCRIPTION
1. Bugfix-GCP-INVEN-009-060 > Firestore > Index > Index 데이터 불일치
- What: spaceONE의 Firestore > Index > Index 데이터 불일치
- Why: 통합 테스트 중 오류 발결
- Impact:  Firestore > Index > Index 탭

2. Bugfix-GCP-INVEN-006-029 > Datastore > Namespace > 원본 데이터에 logging 필드 없음
- What: spaceONE의 Datastore > Namespace > 원본 데이터에 logging 필드 없음
- Why: 통합 테스트 중 오류 발결
- Impact:  Datastore > Namespace > 원본 데이터

3. Bugfix-GCP-INVEN-009-014 > Firestore > Backup > 원본 데이터에 logging 필드 없음
- What: spaceONE의 Firestore > Backup > 원본 데이터에 logging 필드 없음
- Why: 통합 테스트 중 오류 발결
- Impact:  Firestore > Backup > 원본 데이터

3. Bugfix-GCP-INVEN-009-026 > Firestore > BackupSchedule > 원본 데이터에 logging 필드 없음
- What: spaceONE의 Firestore > BackupSchedule > 원본 데이터에 logging 필드 없음
- Why: 통합 테스트 중 오류 발결
- Impact:  Firestore > BackupSchedule > 원본 데이터