### PR TITLE
PR: from feature/julia to aramco -Bugfix: GKE Cluster addonsConfig Boolean 값 스키마 오류 수정

### DIFF
--- a/src/spaceone/inventory/manager/kubernetes_engine/cluster_v1beta_manager.py
+++ b/src/spaceone/inventory/manager/kubernetes_engine/cluster_v1beta_manager.py
@@ -640,7 +640,7 @@ class GKEClusterV1BetaManager(GoogleCloudManager):
                     # 모든 애드온을 동적으로 처리하여 구조 보존
                     processed_addons = {}
                     for addon_key, addon_value in addons_config.items():
-                        # 딕셔너리는 구조 그대로 유지, 다른 타입은 문자열로 변환
+                        # 딕셔너리는 구조 그대로 유지 (Boolean 값 포함)
                         if isinstance(addon_value, dict):
                             processed_addons[addon_key] = addon_value
                         else:

--- a/src/spaceone/inventory/model/kubernetes_engine/cluster/data.py
+++ b/src/spaceone/inventory/model/kubernetes_engine/cluster/data.py
@@ -356,7 +356,7 @@ class GKECluster(BaseResource):
         StringType, deserialize_from="monitoringConfig", serialize_when_none=False
     )
     addons_config = DictType(
-        UnionType([DictType(StringType), StringType]),
+        UnionType([DictType(UnionType([StringType, BooleanType])), StringType]),
         deserialize_from="addonsConfig",
         serialize_when_none=False,
     )
@@ -366,14 +366,6 @@ class GKECluster(BaseResource):
     membership_info = DictType(StringType, serialize_when_none=False)
 
     # Resource Limits
-    resource_limits = ListType(DictType(StringType), serialize_when_none=False)
-
-    def reference(self):
-        return {
-            "resource_id": self.self_link,
-            "external_link": f"https://console.cloud.google.com/kubernetes/clusters/details/{self.location}/{self.name}?project={self.project_id}",
-        }
-
     resource_limits = ListType(DictType(StringType), serialize_when_none=False)
 
     def reference(self):


### PR DESCRIPTION
문제:
- addonsConfig의 중첩 딕셔너리에서 disabled/enabled 필드가 Boolean 값(True/False)인데
- 스키마에서는 StringType만 허용하여 'Couldnt interpret True as string' 오류 발생

해결:
- addons_config 스키마를 DictType(UnionType([StringType, BooleanType]))로 수정
- Boolean 값(disabled: true, enabled: false)을 직접 허용하도록 변경
- 중복된 reference 메서드 및 resource_limits 필드 정리

기술적 개선:
- UI에서 addonsConfig의 Boolean 값을 직접 사용 가능
- 스키마 검증 오류 해결로 데이터 무결성 확보
- 코드 중복 제거로 유지보수성 향상

영향받는 addons:
- kubernetesDashboard, networkPolicyConfig, cloudRunConfig
- gcePersistentDiskCsiDriverConfig 등 모든 Boolean 필드

### Category
- [ ] New feature
- [ ] Bug fix
- [ ] Improvement
- [ ] Refactor
- [ ] etc

### Description

### Known issue