### PR TITLE
PR: from Feature/firebase to aramco

### DIFF
--- a/src/spaceone/inventory/model/bigquery/sql_workspace/cloud_service.py
+++ b/src/spaceone/inventory/model/bigquery/sql_workspace/cloud_service.py
@@ -1,21 +1,21 @@
 from schematics.types import PolyModelType
 
-from spaceone.inventory.model.bigquery.sql_workspace.data import *
+from spaceone.inventory.libs.schema.cloud_service import (
+    CloudServiceMeta,
+    CloudServiceResource,
+    CloudServiceResponse,
+)
 from spaceone.inventory.libs.schema.metadata.dynamic_field import (
-    TextDyField,
     DateTimeDyField,
+    TextDyField,
 )
 from spaceone.inventory.libs.schema.metadata.dynamic_layout import (
     ItemDynamicLayout,
-    TableDynamicLayout,
     ListDynamicLayout,
     SimpleTableDynamicLayout,
+    TableDynamicLayout,
 )
-from spaceone.inventory.libs.schema.cloud_service import (
-    CloudServiceResource,
-    CloudServiceResponse,
-    CloudServiceMeta,
-)
+from spaceone.inventory.model.bigquery.sql_workspace.data import *
 
 """
 SQL Workspace
@@ -28,12 +28,6 @@ dataset_details_meta = ItemDynamicLayout.set_fields(
         TextDyField.data_source("ID", "data.id"),
         TextDyField.data_source("Name", "data.name"),
         TextDyField.data_source("Location", "data.location"),
-        TextDyField.data_source(
-            "Default Partition Expires", "data.default_partition_expiration_ms_display"
-        ),
-        TextDyField.data_source(
-            "Default Table Expires", "data.default_table_expiration_ms_display"
-        ),
         DateTimeDyField.data_source("Creation Time", "data.creation_time"),
         DateTimeDyField.data_source("Last Modified Time", "data.last_modified_time"),
     ],

--- a/src/spaceone/inventory/model/bigquery/sql_workspace/cloud_service_type.py
+++ b/src/spaceone/inventory/model/bigquery/sql_workspace/cloud_service_type.py
@@ -1,21 +1,21 @@
 import os
 
+from spaceone.inventory.conf.cloud_service_conf import ASSET_URL
 from spaceone.inventory.libs.common_parser import *
+from spaceone.inventory.libs.schema.cloud_service_type import (
+    CloudServiceTypeMeta,
+    CloudServiceTypeResource,
+    CloudServiceTypeResponse,
+)
+from spaceone.inventory.libs.schema.metadata.dynamic_field import (
+    DateTimeDyField,
+    SearchField,
+    TextDyField,
+)
 from spaceone.inventory.libs.schema.metadata.dynamic_widget import (
     CardWidget,
     ChartWidget,
 )
-from spaceone.inventory.libs.schema.metadata.dynamic_field import (
-    TextDyField,
-    SearchField,
-    DateTimeDyField,
-)
-from spaceone.inventory.libs.schema.cloud_service_type import (
-    CloudServiceTypeResource,
-    CloudServiceTypeResponse,
-    CloudServiceTypeMeta,
-)
-from spaceone.inventory.conf.cloud_service_conf import ASSET_URL
 
 current_dir = os.path.abspath(os.path.dirname(__file__))
 
@@ -38,13 +38,6 @@ cst_sql_workspace.tags = {
 cst_sql_workspace._metadata = CloudServiceTypeMeta.set_meta(
     fields=[
         TextDyField.data_source("Location", "data.location"),
-        TextDyField.data_source(
-            "Default Partition Expires(Minutes)",
-            "data.default_partition_expiration_ms_display",
-        ),
-        TextDyField.data_source(
-            "Default Table Expires(Minutes)", "data.default_table_expiration_ms_display"
-        ),
         DateTimeDyField.data_source("Creation Time", "data.creation_time"),
         DateTimeDyField.data_source("Last Modified Time", "data.last_modified_time"),
     ],

--- a/src/spaceone/inventory/model/cloud_sql/instance/cloud_service.py
+++ b/src/spaceone/inventory/model/cloud_sql/instance/cloud_service.py
@@ -1,21 +1,21 @@
-from schematics.types import ModelType, StringType, PolyModelType
+from schematics.types import ModelType, PolyModelType, StringType
 
-from spaceone.inventory.model.cloud_sql.instance.data import Instance
+from spaceone.inventory.libs.schema.cloud_service import (
+    CloudServiceMeta,
+    CloudServiceResource,
+    CloudServiceResponse,
+)
 from spaceone.inventory.libs.schema.metadata.dynamic_field import (
-    TextDyField,
+    DateTimeDyField,
     EnumDyField,
     ListDyField,
-    DateTimeDyField,
+    TextDyField,
 )
 from spaceone.inventory.libs.schema.metadata.dynamic_layout import (
     ItemDynamicLayout,
     TableDynamicLayout,
 )
-from spaceone.inventory.libs.schema.cloud_service import (
-    CloudServiceResource,
-    CloudServiceResponse,
-    CloudServiceMeta,
-)
+from spaceone.inventory.model.cloud_sql.instance.data import Instance
 
 """
 SQL Instance
@@ -67,11 +67,6 @@ sql_meta_configuration = ItemDynamicLayout.set_fields(
             "data.settings.storage_auto_resize_limit",
         ),
         EnumDyField.data_source(
-            "Point-in-time recovery",
-            "data.settings.storage_auto_resize",
-            default_badge={},
-        ),
-        EnumDyField.data_source(
             "Availability Type",
             "data.settings.availability_type",
             default_outline_badge=[
@@ -119,12 +114,6 @@ sql_meta_database = TableDynamicLayout.set_fields(
         TextDyField.data_source("Name", "name"),
         TextDyField.data_source("charset", "charset"),
         TextDyField.data_source("collation", "collation"),
-        TextDyField.data_source(
-            "Compatibility Level", "sql_server_database_details.compatibility_level"
-        ),
-        TextDyField.data_source(
-            "Recovery Model", "sql_server_database_details.recovery_model"
-        ),
         TextDyField.data_source("Self Link", "self_link"),
     ],
 )
@@ -135,17 +124,7 @@ sql_meta_user = TableDynamicLayout.set_fields(
     "data.users",
     fields=[
         TextDyField.data_source("User Name", "name"),
-        EnumDyField.data_source(
-            "State",
-            "sql_server_user_details.disabled",
-            default_badge={"indigo.500": ["true"], "coral.600": ["false"]},
-        ),
         TextDyField.data_source("Host", "host"),
-        ListDyField.data_source(
-            "Server Roles",
-            "sql_server_user_details.server_roles",
-            default_badge={"type": "outline", "delimiter": "<br>"},
-        ),
     ],
 )
 
@@ -167,16 +146,6 @@ sql_meta_backup = ItemDynamicLayout.set_fields(
         EnumDyField.data_source(
             "Binary Log Enabled",
             "data.settings.backup_configuration.binary_log_enabled",
-            default_badge={"indigo.500": ["true"], "coral.600": ["false"]},
-        ),
-        EnumDyField.data_source(
-            "Replication Log Archiving Enabled",
-            "data.settings.backup_configuration.replication_log_archiving_enabled",
-            default_badge={"indigo.500": ["true"], "coral.600": ["false"]},
-        ),
-        EnumDyField.data_source(
-            "Point In Time Recovery Enabled",
-            "data.settings.backup_configuration.point_in_time_recovery_enabled",
             default_badge={"indigo.500": ["true"], "coral.600": ["false"]},
         ),
     ],

--- a/src/spaceone/inventory/model/cloud_sql/instance/cloud_service_type.py
+++ b/src/spaceone/inventory/model/cloud_sql/instance/cloud_service_type.py
@@ -48,7 +48,6 @@ cst_instance._metadata = CloudServiceTypeMeta.set_meta(
             },
         ),
         TextDyField.data_source("Type", "data.database_version"),
-        TextDyField.data_source("Project", "data.project"),
         ListDyField.data_source(
             "Public IP Address",
             "data.ip_addresses",

--- a/src/spaceone/inventory/model/cloud_sql/instance/data.py
+++ b/src/spaceone/inventory/model/cloud_sql/instance/data.py
@@ -1,19 +1,25 @@
 from schematics import Model
 from schematics.types import (
-    ModelType,
-    ListType,
-    StringType,
+    BaseType,
     BooleanType,
-    IntType,
     DateTimeType,
     DictType,
+    IntType,
+    ListType,
+    ModelType,
+    StringType,
 )
+
 from spaceone.inventory.libs.schema.cloud_service import BaseResource
 
 
 class SQLServerUserDetail(Model):
     disabled = BooleanType()
     server_roles = ListType(StringType, deserialize_from="serverRoles")
+
+
+class PasswordPolicy(Model):
+    status = DictType(BaseType, default={})
 
 
 class User(Model):
@@ -23,6 +29,9 @@ class User(Model):
     host = StringType()
     instance = StringType()
     project = StringType()
+    password_policy = ModelType(
+        PasswordPolicy, deserialize_from="passwordPolicy", serialize_when_none=False
+    )
     sql_server_user_details = ModelType(
         SQLServerUserDetail,
         deserialize_from="sqlserverUserDetails",


### PR DESCRIPTION
  Refactor-GCP-INVEN-013-CloudSQL-View

   - What: Removed multiple non-essential and engine-specific fields from the Cloud SQL instance detail view.
   - Why: To simplify and declutter the UI by removing redundant or overly specific fields, providing a cleaner user experience.
   - Impact: The detail tabs (Configuration, Databases, Users, Backup) for Cloud SQL instances now display a more streamlined set of information.