### PR TITLE
PR: from feature/batch to aramco 

### DIFF
--- a/src/spaceone/inventory/model/cloud_sql/instance/cloud_service_type.py
+++ b/src/spaceone/inventory/model/cloud_sql/instance/cloud_service_type.py
@@ -1,22 +1,22 @@
 import os
 
+from spaceone.inventory.conf.cloud_service_conf import *
 from spaceone.inventory.libs.common_parser import *
+from spaceone.inventory.libs.schema.cloud_service_type import (
+    CloudServiceTypeMeta,
+    CloudServiceTypeResource,
+    CloudServiceTypeResponse,
+)
+from spaceone.inventory.libs.schema.metadata.dynamic_field import (
+    EnumDyField,
+    ListDyField,
+    SearchField,
+    TextDyField,
+)
 from spaceone.inventory.libs.schema.metadata.dynamic_widget import (
     CardWidget,
     ChartWidget,
 )
-from spaceone.inventory.libs.schema.metadata.dynamic_field import (
-    TextDyField,
-    ListDyField,
-    SearchField,
-    EnumDyField,
-)
-from spaceone.inventory.libs.schema.cloud_service_type import (
-    CloudServiceTypeResource,
-    CloudServiceTypeResponse,
-    CloudServiceTypeMeta,
-)
-from spaceone.inventory.conf.cloud_service_conf import *
 
 current_dir = os.path.abspath(os.path.dirname(__file__))
 
@@ -64,9 +64,6 @@ cst_instance._metadata = CloudServiceTypeMeta.set_meta(
         ),
         TextDyField.data_source(
             "Connection name", "data.connection_name", options={"is_optional": True}
-        ),
-        TextDyField.data_source(
-            "Location", "data.gce_zone", options={"is_optional": True}
         ),
         TextDyField.data_source(
             "Service Account",


### PR DESCRIPTION
  Refactor-GCP-INVEN-015-003-CloudSQL-View

   - What: Cloud SQL 인스턴스의 상세 보기 메타데이터에서 'Location' 필드를 제거했습니다.
   - Why: 위치 정보는 이미 주요 상세 정보에 포함되어 있으므로, 중복 정보를 제거하여 UI를 단순화하기 위함입니다.
   - Impact: 이제 Cloud SQL 인스턴스의 상세 보기 하단 정보 섹션에 'Location' 필드가 표시되지 않습니다.
