### PR TITLE
PR: from feature/computeengine to aramco / Bugfix-ComputeEngine

### DIFF
--- a/src/spaceone/inventory/model/compute_engine/machine_image/cloud_service.py
+++ b/src/spaceone/inventory/model/compute_engine/machine_image/cloud_service.py
@@ -149,7 +149,7 @@ it_meta_network = TableDynamicLayout.set_fields(
         TextDyField.data_source("Primary internal IP", "primary_ip_address"),
         ListDyField.data_source(
             "Alias IP range",
-            "alias_ip_ranges.ipCidrRange",
+            "ip_ranges",
             default_badge={"type": "outline", "delimiter": "<br>"},
         ),
         TextDyField.data_source("Public IP", "public_ip_address"),


### PR DESCRIPTION
Bugfix-GCP-INVEN-017-082 > ComputeEngine > MachineImage > Network Interface TAB > Alias IP range, Access Configs field not exposed
FIX : Alias IP range, Access Configs field not exposed