### PR TITLE
PR: from feature/batch to aramco / Bugfix-GCP-INVEN-Metadata-Display

### DIFF
--- a/src/spaceone/inventory/model/bigquery/sql_workspace/cloud_service.py
+++ b/src/spaceone/inventory/model/bigquery/sql_workspace/cloud_service.py
@@ -13,7 +13,6 @@ from spaceone.inventory.libs.schema.metadata.dynamic_layout import (
     ItemDynamicLayout,
     ListDynamicLayout,
     SimpleTableDynamicLayout,
-    TableDynamicLayout,
 )
 from spaceone.inventory.model.bigquery.sql_workspace.data import *
 
@@ -47,20 +46,9 @@ workspace_dataset_meta = ListDynamicLayout.set_layouts(
     "Dataset Details", layouts=[dataset_details_meta, access_table_meta]
 )
 
-
-workspace_labels_meta = TableDynamicLayout.set_fields(
-    "Labels",
-    root_path="data.labels",
-    fields=[
-        TextDyField.data_source("Key", "key"),
-        TextDyField.data_source("Value", "value"),
-    ],
-)
-
 big_query_workspace_meta = CloudServiceMeta.set_layouts(
     [
         workspace_dataset_meta,
-        workspace_labels_meta,
     ]
 )
 

--- a/src/spaceone/inventory/model/firebase/app/data.py
+++ b/src/spaceone/inventory/model/firebase/app/data.py
@@ -78,19 +78,9 @@ firebase_app_details = ItemDynamicLayout.set_fields(
     ],
 )
 
-# TAB - Timestamps
-firebase_app_timestamps = ItemDynamicLayout.set_fields(
-    "Timestamps",
-    fields=[
-        TextDyField.data_source("Project ID", "data.project_id"),
-        TextDyField.data_source("Full Name", "data.full_name"),
-    ],
-)
-
 # Unified metadata layout
 firebase_app_meta = CloudServiceMeta.set_layouts(
     [
         firebase_app_details,
-        firebase_app_timestamps,
     ]
 )


### PR DESCRIPTION
 Bugfix-GCP-INVEN-Metadata-Display
   
   - What: Removed redundant UI layouts from the metadata of BigQuery SQL Workspace and Firebase App.
   - Why: To clean up the UI by removing a redundant Labels tab and an incorrect Timestamps tab.
   - Impact: A cleaner UI for BigQuery and Firebase resources with unnecessary tabs removed.