### PR TITLE
feat: Add global retry and timeout configuration with monkey patching

### DIFF
--- a/src/spaceone/inventory/conf/client_config.py
+++ b/src/spaceone/inventory/conf/client_config.py
@@ -1,0 +1,89 @@
+"""Google Cloud client common configuration management module
+
+This module centrally manages retry and timeout settings for Google Cloud clients.
+Configuration priority: options parameter > default constants
+"""
+
+import logging
+from typing import Optional
+
+_LOGGER = logging.getLogger("spaceone")
+
+# Default constants
+DEFAULT_MAX_RETRY_ATTEMPTS = 1
+DEFAULT_TIMEOUT_SECONDS = 120
+
+
+class ClientConfig:
+    """Class for managing Google Cloud client configuration"""
+
+    def __init__(self, options: dict = None):
+        """Initialize configuration.
+
+        Args:
+            options: Options dictionary passed from collector_collect function
+        """
+        options = options or {}
+
+        # Load configuration values (options -> default values order)
+        self.max_retry_attempts = int(
+            options.get("max_retry_attempts") or DEFAULT_MAX_RETRY_ATTEMPTS
+        )
+
+        self.timeout_seconds = float(
+            options.get("timeout_seconds") or DEFAULT_TIMEOUT_SECONDS
+        )
+
+        _LOGGER.debug(
+            f"Google Cloud client configuration: "
+            f"max_retry_attempts={self.max_retry_attempts}, "
+            f"timeout={self.timeout_seconds}s"
+        )
+
+    def get_max_retry_attempts(self) -> int:
+        """Return max retry attempts."""
+        return self.max_retry_attempts
+
+    def get_timeout(self) -> int:
+        """Return HTTP timeout configuration."""
+        return self.timeout_seconds
+
+
+class ClientConfigManager:
+    """Manager for globally managing Google Cloud client configuration"""
+
+    _config: Optional[ClientConfig] = None
+
+    @classmethod
+    def initialize(cls, options: dict = None) -> None:
+        """Initialize global configuration.
+
+        Args:
+            options: Configuration options dictionary
+        """
+        cls._config = ClientConfig(options)
+        _LOGGER.info("Google Cloud client configuration initialization completed")
+
+    @classmethod
+    def get_config(cls) -> ClientConfig:
+        """Return current configuration.
+
+        Returns:
+            ClientConfig instance
+
+        Note:
+            Auto-initializes with defaults if not initialized
+        """
+        if cls._config is None:
+            cls.initialize()
+            _LOGGER.debug("ClientConfigManager auto-initialized with default values")
+        return cls._config
+
+    @classmethod
+    def is_initialized(cls) -> bool:
+        """Check if configuration is initialized.
+
+        Returns:
+            True if initialized, False otherwise
+        """
+        return cls._config is not None

--- a/src/spaceone/inventory/connector/kms/kms_v1.py
+++ b/src/spaceone/inventory/connector/kms/kms_v1.py
@@ -177,9 +177,11 @@ class KMSConnector(GoogleCloudConnector):
                             key_ring["location_data"] = location_data
                             all_key_rings.append(key_ring)
 
-                except Exception:
-                    # 권한이 없는 location에 대한 접근은 정상적인 상황이므로 로그 출력하지 않음
-                    # _LOGGER.debug(f"Location {location_id} not accessible or no permission: {e}")
+                except Exception as e:
+                    # 디버깅: 예외 로그 출력
+                    _LOGGER.warning(
+                        f"Failed to list key rings in location {location_id}: {type(e).__name__}: {e}"
+                    )
                     continue
 
             _LOGGER.info(

--- a/src/spaceone/inventory/libs/connector.py
+++ b/src/spaceone/inventory/libs/connector.py
@@ -1,12 +1,15 @@
 import logging
+from functools import wraps
 
 import google.oauth2.service_account
-import googleapiclient
+import google_auth_httplib2
 import googleapiclient.discovery
+import httplib2
+from googleapiclient.http import HttpRequest
 
 from spaceone.core.connector import BaseConnector
+from spaceone.inventory.conf.client_config import ClientConfigManager
 
-DEFAULT_SCHEMA = "google_oauth_client_id"
 _LOGGER = logging.getLogger(__name__)
 
 
@@ -40,19 +43,69 @@ class GoogleCloudConnector(BaseConnector):
             raise ValueError("project_id is required in secret_data")
 
         try:
-            self.credentials = (
+            # 인증 정보 생성 (Cloud Platform scope 추가)
+            credentials = (
                 google.oauth2.service_account.Credentials.from_service_account_info(
-                    secret_data
+                    secret_data,
+                    scopes=["https://www.googleapis.com/auth/cloud-platform"],
                 )
             )
-            self.client = googleapiclient.discovery.build(
-                self.google_client_service, self.version, credentials=self.credentials
+
+            # 타임아웃 및 재시도 설정 로드
+            timeout = self.get_timeout()
+            self.max_retry_attempts = self.get_max_retry_attempts()
+
+            # HTTP 클라이언트 생성 (타임아웃 적용)
+            http = httplib2.Http(timeout=timeout)
+
+            # 인증된 HTTP 클라이언트 생성
+            authorized_http = google_auth_httplib2.AuthorizedHttp(
+                credentials, http=http
             )
+
+            # API 클라이언트 생성 (인증된 http만 전달)
+            self.client = googleapiclient.discovery.build(
+                self.google_client_service,
+                self.version,
+                http=authorized_http,
+                cache_discovery=False,
+            )
+
+            # HttpRequest.execute()에 num_retries 자동 주입
+            self._patch_execute_method()
+
+            _LOGGER.info(
+                f"Connector initialized: "
+                f"service={self.google_client_service}, "
+                f"timeout={timeout}s, "
+                f"max_retry_attempts={self.max_retry_attempts}"
+            )
+
         except Exception as e:
-            _LOGGER.error(f"Failed to initialize Google Cloud client: {e}")
-            raise ValueError(
-                f"Invalid credentials or service configuration: {e}"
-            ) from e
+            _LOGGER.error(f"Failed to initialize: {e}")
+            raise ValueError(f"Invalid credentials: {e}") from e
+
+    def _patch_execute_method(self):
+        """HttpRequest.execute()에 num_retries를 자동 주입하는 monkey patch"""
+        if hasattr(HttpRequest.execute, "_is_patched"):
+            return
+
+        original_execute = HttpRequest.execute
+        default_num_retries = self.max_retry_attempts
+
+        @wraps(original_execute)
+        def execute_with_default_retries(request_self, http=None, num_retries=None):
+            if num_retries is None:
+                num_retries = default_num_retries
+
+            # float를 int로 변환 (API에서 5.0으로 올 수 있음)
+            num_retries = int(num_retries)
+
+            # googleapiclient 기본 재시도 사용
+            return original_execute(request_self, http, num_retries)
+
+        execute_with_default_retries._is_patched = True
+        HttpRequest.execute = execute_with_default_retries
 
     def verify(self, **kwargs):
         if self.client is None:
@@ -66,7 +119,17 @@ class GoogleCloudConnector(BaseConnector):
         )
         return query
 
+    def get_max_retry_attempts(self) -> int:
+        """최대 재시도 횟수 반환"""
+        return ClientConfigManager.get_config().get_max_retry_attempts()
+
+    def get_timeout(self) -> int:
+        """HTTP 타임아웃 설정 반환 (초)"""
+        return ClientConfigManager.get_config().get_timeout()
+
     def list_zones(self, **query):
+        """zone 목록 조회"""
         query = self.generate_query(**query)
-        result = self.client.zones().list(**query).execute()
+        request = self.client.zones().list(**query)
+        result = request.execute()
         return result.get("items", [])

--- a/src/spaceone/inventory/service/collector_service.py
+++ b/src/spaceone/inventory/service/collector_service.py
@@ -10,6 +10,7 @@ from spaceone.core.service import (
     check_required,
     transaction,
 )
+from spaceone.inventory.conf.client_config import ClientConfigManager
 from spaceone.inventory.conf.cloud_service_conf import (
     CLOUD_SERVICE_GROUP_MAP,
     FILTER_FORMAT,
@@ -102,6 +103,10 @@ class CollectorService(BaseService):
                 - secret_data
                 - filter
         """
+
+        # ClientConfigManager 전역 설정 초기화
+        options = params.get("options", {})
+        ClientConfigManager.initialize(options)
 
         # Project validation을 건너뛰고 바로 매니저 실행으로 진행
         secret_data = params.get("secret_data", {})


### PR DESCRIPTION
 Feat-GCP-CORE-001-Retry-Timeout
   
   - What: API 재시도 및 타임아웃 전역 설정 기능 구현
   - Why: 커넥터별로 분산되어 있던 API 호출 정책을 일원화하여 안정성 및 예측 가능성 향상
   - Impact: 모든 GCP API 호출에 일관된 타임아웃 및 재시도 로직이 적용되어 컬렉터 안정성 증대