### PR TITLE
PR: from feature/icon to aramco

### DIFF
--- a/src/spaceone/inventory/metrics/Batch/Job/namespace.yaml
+++ b/src/spaceone/inventory/metrics/Batch/Job/namespace.yaml
@@ -2,7 +2,7 @@
 namespace_id: ns-google-cloud-batch-job
 name: Batch/Job
 category: ASSET
-icon: "https://spaceone-custom-assets.s3.ap-northeast-2.amazonaws.com/console-assets/icons/cloud-services/google_cloud/Batch.svg"
-version: "1.1"
+icon: 'https://spaceone-custom-assets.s3.ap-northeast-2.amazonaws.com/console-assets/icons/cloud-services/google_cloud/Batch.svg'
+version: '1.1'
 resource_type: inventory.CloudService:google_cloud.Batch.Job
 group: google_cloud

--- a/src/spaceone/inventory/metrics/CloudBuild/CloudBuild/namespace.yaml
+++ b/src/spaceone/inventory/metrics/CloudBuild/CloudBuild/namespace.yaml
@@ -2,7 +2,7 @@
 namespace_id: ns-google-cloud-cloudbuild-build
 name: CloudBuild/Build
 category: ASSET
-icon: "https://spaceone-custom-assets.s3.ap-northeast-2.amazonaws.com/console-assets/icons/cloud-services/google_cloud/Cloud-Build.svg"
-version: "1.1"
+icon: 'https://spaceone-custom-assets.s3.ap-northeast-2.amazonaws.com/console-assets/icons/cloud-services/google_cloud/Cloud-Build.svg'
+version: '1.1'
 resource_type: inventory.CloudService:google_cloud.CloudBuild.Build
 group: google_cloud

--- a/src/spaceone/inventory/metrics/CloudBuild/Connection/namespace.yaml
+++ b/src/spaceone/inventory/metrics/CloudBuild/Connection/namespace.yaml
@@ -2,7 +2,7 @@
 namespace_id: ns-google-cloud-cloudbuild-connection
 name: CloudBuild/Connection
 category: ASSET
-icon: "https://spaceone-custom-assets.s3.ap-northeast-2.amazonaws.com/console-assets/icons/cloud-services/google_cloud/Cloud-Build.svg"
-version: "1.1"
+icon: 'https://spaceone-custom-assets.s3.ap-northeast-2.amazonaws.com/console-assets/icons/cloud-services/google_cloud/Cloud-Build.svg'
+version: '1.1'
 resource_type: inventory.CloudService:google_cloud.CloudBuild.Connection
 group: google_cloud

--- a/src/spaceone/inventory/metrics/CloudBuild/Repository/namespace.yaml
+++ b/src/spaceone/inventory/metrics/CloudBuild/Repository/namespace.yaml
@@ -2,7 +2,7 @@
 namespace_id: ns-google-cloud-cloudbuild-repository
 name: CloudBuild/Repository
 category: ASSET
-icon: "https://spaceone-custom-assets.s3.ap-northeast-2.amazonaws.com/console-assets/icons/cloud-services/google_cloud/Cloud-Build.svg"
-version: "1.1"
+icon: 'https://spaceone-custom-assets.s3.ap-northeast-2.amazonaws.com/console-assets/icons/cloud-services/google_cloud/Cloud-Build.svg'
+version: '1.1'
 resource_type: inventory.CloudService:google_cloud.CloudBuild.Repository
 group: google_cloud

--- a/src/spaceone/inventory/metrics/CloudBuild/Trigger/namespace.yaml
+++ b/src/spaceone/inventory/metrics/CloudBuild/Trigger/namespace.yaml
@@ -2,7 +2,7 @@
 namespace_id: ns-google-cloud-cloudbuild-trigger
 name: CloudBuild/Trigger
 category: ASSET
-icon: "https://spaceone-custom-assets.s3.ap-northeast-2.amazonaws.com/console-assets/icons/cloud-services/google_cloud/Cloud-Build.svg"
-version: "1.1"
+icon: 'https://spaceone-custom-assets.s3.ap-northeast-2.amazonaws.com/console-assets/icons/cloud-services/google_cloud/Cloud-Build.svg'
+version: '1.1'
 resource_type: inventory.CloudService:google_cloud.CloudBuild.Trigger
 group: google_cloud

--- a/src/spaceone/inventory/metrics/CloudBuild/WorkerPool/namespace.yaml
+++ b/src/spaceone/inventory/metrics/CloudBuild/WorkerPool/namespace.yaml
@@ -2,7 +2,7 @@
 namespace_id: ns-google-cloud-cloudbuild-worker_pool
 name: CloudBuild/WorkerPool
 category: ASSET
-icon: "https://spaceone-custom-assets.s3.ap-northeast-2.amazonaws.com/console-assets/icons/cloud-services/google_cloud/Cloud-Build.svg"
-version: "1.1"
+icon: 'https://spaceone-custom-assets.s3.ap-northeast-2.amazonaws.com/console-assets/icons/cloud-services/google_cloud/Cloud-Build.svg'
+version: '1.1'
 resource_type: inventory.CloudService:google_cloud.CloudBuild.WorkerPool
 group: google_cloud

--- a/src/spaceone/inventory/metrics/CloudRun/Configuration/namespace.yaml
+++ b/src/spaceone/inventory/metrics/CloudRun/Configuration/namespace.yaml
@@ -2,7 +2,7 @@
 namespace_id: ns-google-cloud-cloudrun-configuration
 name: CloudRun/Configuration
 category: ASSET
-icon: "https://spaceone-custom-assets.s3.ap-northeast-2.amazonaws.com/console-assets/icons/cloud-services/google_cloud/Cloud-Run.svg"
-version: "1.1"
+icon: 'https://spaceone-custom-assets.s3.ap-northeast-2.amazonaws.com/console-assets/icons/cloud-services/google_cloud/Cloud-Run.svg'
+version: '1.1'
 resource_type: inventory.CloudService:google_cloud.CloudRun.Configuration
 group: google_cloud

--- a/src/spaceone/inventory/metrics/CloudRun/DomainMapping/namespace.yaml
+++ b/src/spaceone/inventory/metrics/CloudRun/DomainMapping/namespace.yaml
@@ -2,7 +2,7 @@
 namespace_id: ns-google-cloud-cloudrun-domain_mapping
 name: CloudRun/DomainMapping
 category: ASSET
-icon: "https://spaceone-custom-assets.s3.ap-northeast-2.amazonaws.com/console-assets/icons/cloud-services/google_cloud/Cloud-Run.svg"
-version: "1.1"
+icon: 'https://spaceone-custom-assets.s3.ap-northeast-2.amazonaws.com/console-assets/icons/cloud-services/google_cloud/Cloud-Run.svg'
+version: '1.1'
 resource_type: inventory.CloudService:google_cloud.CloudRun.DomainMapping
 group: google_cloud

--- a/src/spaceone/inventory/metrics/CloudRun/Job/namespace.yaml
+++ b/src/spaceone/inventory/metrics/CloudRun/Job/namespace.yaml
@@ -2,7 +2,7 @@
 namespace_id: ns-google-cloud-cloudrun-job
 name: CloudRun/Job
 category: ASSET
-icon: "https://spaceone-custom-assets.s3.ap-northeast-2.amazonaws.com/console-assets/icons/cloud-services/google_cloud/Cloud-Run.svg"
-version: "1.1"
+icon: 'https://spaceone-custom-assets.s3.ap-northeast-2.amazonaws.com/console-assets/icons/cloud-services/google_cloud/Cloud-Run.svg'
+version: '1.1'
 resource_type: inventory.CloudService:google_cloud.CloudRun.Job
 group: google_cloud

--- a/src/spaceone/inventory/metrics/CloudRun/Operation/namespace.yaml
+++ b/src/spaceone/inventory/metrics/CloudRun/Operation/namespace.yaml
@@ -2,7 +2,7 @@
 namespace_id: ns-google-cloud-cloudrun-operation
 name: CloudRun/Operation
 category: ASSET
-icon: "https://spaceone-custom-assets.s3.ap-northeast-2.amazonaws.com/console-assets/icons/cloud-services/google_cloud/Cloud-Run.svg"
-version: "1.1"
+icon: 'https://spaceone-custom-assets.s3.ap-northeast-2.amazonaws.com/console-assets/icons/cloud-services/google_cloud/Cloud-Run.svg'
+version: '1.1'
 resource_type: inventory.CloudService:google_cloud.CloudRun.Operation
 group: google_cloud

--- a/src/spaceone/inventory/metrics/CloudRun/Route/namespace.yaml
+++ b/src/spaceone/inventory/metrics/CloudRun/Route/namespace.yaml
@@ -2,7 +2,7 @@
 namespace_id: ns-google-cloud-cloudrun-route
 name: CloudRun/Route
 category: ASSET
-icon: "https://spaceone-custom-assets.s3.ap-northeast-2.amazonaws.com/console-assets/icons/cloud-services/google_cloud/Cloud-Run.svg"
-version: "1.1"
+icon: 'https://spaceone-custom-assets.s3.ap-northeast-2.amazonaws.com/console-assets/icons/cloud-services/google_cloud/Cloud-Run.svg'
+version: '1.1'
 resource_type: inventory.CloudService:google_cloud.CloudRun.Route
 group: google_cloud

--- a/src/spaceone/inventory/metrics/CloudRun/Service/namespace.yaml
+++ b/src/spaceone/inventory/metrics/CloudRun/Service/namespace.yaml
@@ -2,7 +2,7 @@
 namespace_id: ns-google-cloud-cloudrun-service
 name: CloudRun/Service
 category: ASSET
-icon: "https://spaceone-custom-assets.s3.ap-northeast-2.amazonaws.com/console-assets/icons/cloud-services/google_cloud/Cloud-Run.svg"
-version: "1.1"
+icon: 'https://spaceone-custom-assets.s3.ap-northeast-2.amazonaws.com/console-assets/icons/cloud-services/google_cloud/Cloud-Run.svg'
+version: '1.1'
 resource_type: inventory.CloudService:google_cloud.CloudRun.Service
 group: google_cloud

--- a/src/spaceone/inventory/metrics/CloudRun/WorkerPool/namespace.yaml
+++ b/src/spaceone/inventory/metrics/CloudRun/WorkerPool/namespace.yaml
@@ -2,7 +2,7 @@
 namespace_id: ns-google-cloud-cloudrun-worker_pool
 name: CloudRun/WorkerPool
 category: ASSET
-icon: "https://spaceone-custom-assets.s3.ap-northeast-2.amazonaws.com/console-assets/icons/cloud-services/google_cloud/Cloud-Run.svg"
-version: "1.1"
+icon: 'https://spaceone-custom-assets.s3.ap-northeast-2.amazonaws.com/console-assets/icons/cloud-services/google_cloud/Cloud-Run.svg'
+version: '1.1'
 resource_type: inventory.CloudService:google_cloud.CloudRun.WorkerPool
 group: google_cloud

--- a/src/spaceone/inventory/metrics/ComputeEngine/InstanceTemplate/namespace.yaml
+++ b/src/spaceone/inventory/metrics/ComputeEngine/InstanceTemplate/namespace.yaml
@@ -2,7 +2,7 @@
 namespace_id: ns-google-cloud-ce-instance-template
 name: ComputeEngine/InstanceTemplate
 category: ASSET
-icon: 'https://spaceoneock-custom-assets.s3.ap-northeast-2.amazonaws.com/console-assets/icons/cloud-services/google_cloud/Compute_Engine.svg'
+icon: 'https://spaceone-custom-assets.s3.ap-northeast-2.amazonaws.com/console-assets/icons/cloud-services/google_cloud/Compute_Engine.svg'
 version: '1.1'
 resource_type: inventory.CloudService:google_cloud.ComputeEngine.InstanceTemplate
 group: google_cloud


### PR DESCRIPTION
Style-Metrics-GCP-INVEN-002-Standardize-YAML-Quoting

   - What: Standardized string quoting by replacing double quotes with single quotes in metric namespace YAML files.
   - Why: To maintain a consistent coding style across all YAML configuration files, aligning with project-wide formatting standards.
   - Impact: This is a purely stylistic change with no functional impact on the application's logic or data collection.