### PR TITLE
PR: from feature/icon to aramco

### DIFF
--- a/src/spaceone/inventory/libs/connector.py
+++ b/src/spaceone/inventory/libs/connector.py
@@ -74,13 +74,6 @@ class GoogleCloudConnector(BaseConnector):
             # HttpRequest.execute()에 num_retries 자동 주입
             self._patch_execute_method()
 
-            _LOGGER.info(
-                f"Connector initialized: "
-                f"service={self.google_client_service}, "
-                f"timeout={timeout}s, "
-                f"max_retry_attempts={self.max_retry_attempts}"
-            )
-
         except Exception as e:
             _LOGGER.error(f"Failed to initialize: {e}")
             raise ValueError(f"Invalid credentials: {e}") from e

--- a/src/spaceone/inventory/metrics/AppEngine/Application/namespace.yaml
+++ b/src/spaceone/inventory/metrics/AppEngine/Application/namespace.yaml
@@ -3,6 +3,6 @@ namespace_id: ns-google-cloud-appengine-application
 name: AppEngine/Application
 category: ASSET
 icon: 'https://spaceone-custom-assets.s3.ap-northeast-2.amazonaws.com/console-assets/icons/cloud-services/google_cloud/App-Engine.svg'
-version: '1.1'
+version: '1.2'
 resource_type: inventory.CloudService:google_cloud.AppEngine.Application
 group: google_cloud

--- a/src/spaceone/inventory/metrics/AppEngine/Instance/namespace.yaml
+++ b/src/spaceone/inventory/metrics/AppEngine/Instance/namespace.yaml
@@ -3,6 +3,6 @@ namespace_id: ns-google-cloud-appengine-instance
 name: AppEngine/Instance
 category: ASSET
 icon: 'https://spaceone-custom-assets.s3.ap-northeast-2.amazonaws.com/console-assets/icons/cloud-services/google_cloud/App-Engine.svg'
-version: '1.1'
+version: '1.2'
 resource_type: inventory.CloudService:google_cloud.AppEngine.Instance
 group: google_cloud

--- a/src/spaceone/inventory/metrics/AppEngine/Service/namespace.yaml
+++ b/src/spaceone/inventory/metrics/AppEngine/Service/namespace.yaml
@@ -3,6 +3,6 @@ namespace_id: ns-google-cloud-appengine-service
 name: AppEngine/Service
 category: ASSET
 icon: 'https://spaceone-custom-assets.s3.ap-northeast-2.amazonaws.com/console-assets/icons/cloud-services/google_cloud/App-Engine.svg'
-version: '1.1'
+version: '1.2'
 resource_type: inventory.CloudService:google_cloud.AppEngine.Service
 group: google_cloud

--- a/src/spaceone/inventory/metrics/AppEngine/Version/namespace.yaml
+++ b/src/spaceone/inventory/metrics/AppEngine/Version/namespace.yaml
@@ -3,6 +3,6 @@ namespace_id: ns-google-cloud-appengine-version
 name: AppEngine/Version
 category: ASSET
 icon: 'https://spaceone-custom-assets.s3.ap-northeast-2.amazonaws.com/console-assets/icons/cloud-services/google_cloud/App-Engine.svg'
-version: '1.1'
+version: '1.2'
 resource_type: inventory.CloudService:google_cloud.AppEngine.Version
 group: google_cloud

--- a/src/spaceone/inventory/metrics/Batch/Job/namespace.yaml
+++ b/src/spaceone/inventory/metrics/Batch/Job/namespace.yaml
@@ -3,6 +3,6 @@ namespace_id: ns-google-cloud-batch-job
 name: Batch/Job
 category: ASSET
 icon: 'https://spaceone-custom-assets.s3.ap-northeast-2.amazonaws.com/console-assets/icons/cloud-services/google_cloud/Batch.svg'
-version: '1.1'
+version: '1.2'
 resource_type: inventory.CloudService:google_cloud.Batch.Job
 group: google_cloud

--- a/src/spaceone/inventory/metrics/CloudBuild/CloudBuild/namespace.yaml
+++ b/src/spaceone/inventory/metrics/CloudBuild/CloudBuild/namespace.yaml
@@ -3,6 +3,6 @@ namespace_id: ns-google-cloud-cloudbuild-build
 name: CloudBuild/Build
 category: ASSET
 icon: 'https://spaceone-custom-assets.s3.ap-northeast-2.amazonaws.com/console-assets/icons/cloud-services/google_cloud/Cloud-Build.svg'
-version: '1.1'
+version: '1.2'
 resource_type: inventory.CloudService:google_cloud.CloudBuild.Build
 group: google_cloud

--- a/src/spaceone/inventory/metrics/CloudBuild/Connection/namespace.yaml
+++ b/src/spaceone/inventory/metrics/CloudBuild/Connection/namespace.yaml
@@ -3,6 +3,6 @@ namespace_id: ns-google-cloud-cloudbuild-connection
 name: CloudBuild/Connection
 category: ASSET
 icon: 'https://spaceone-custom-assets.s3.ap-northeast-2.amazonaws.com/console-assets/icons/cloud-services/google_cloud/Cloud-Build.svg'
-version: '1.1'
+version: '1.2'
 resource_type: inventory.CloudService:google_cloud.CloudBuild.Connection
 group: google_cloud

--- a/src/spaceone/inventory/metrics/CloudBuild/Repository/namespace.yaml
+++ b/src/spaceone/inventory/metrics/CloudBuild/Repository/namespace.yaml
@@ -3,6 +3,6 @@ namespace_id: ns-google-cloud-cloudbuild-repository
 name: CloudBuild/Repository
 category: ASSET
 icon: 'https://spaceone-custom-assets.s3.ap-northeast-2.amazonaws.com/console-assets/icons/cloud-services/google_cloud/Cloud-Build.svg'
-version: '1.1'
+version: '1.2'
 resource_type: inventory.CloudService:google_cloud.CloudBuild.Repository
 group: google_cloud

--- a/src/spaceone/inventory/metrics/CloudBuild/Trigger/namespace.yaml
+++ b/src/spaceone/inventory/metrics/CloudBuild/Trigger/namespace.yaml
@@ -3,6 +3,6 @@ namespace_id: ns-google-cloud-cloudbuild-trigger
 name: CloudBuild/Trigger
 category: ASSET
 icon: 'https://spaceone-custom-assets.s3.ap-northeast-2.amazonaws.com/console-assets/icons/cloud-services/google_cloud/Cloud-Build.svg'
-version: '1.1'
+version: '1.2'
 resource_type: inventory.CloudService:google_cloud.CloudBuild.Trigger
 group: google_cloud

--- a/src/spaceone/inventory/metrics/CloudBuild/WorkerPool/namespace.yaml
+++ b/src/spaceone/inventory/metrics/CloudBuild/WorkerPool/namespace.yaml
@@ -3,6 +3,6 @@ namespace_id: ns-google-cloud-cloudbuild-worker_pool
 name: CloudBuild/WorkerPool
 category: ASSET
 icon: 'https://spaceone-custom-assets.s3.ap-northeast-2.amazonaws.com/console-assets/icons/cloud-services/google_cloud/Cloud-Build.svg'
-version: '1.1'
+version: '1.2'
 resource_type: inventory.CloudService:google_cloud.CloudBuild.WorkerPool
 group: google_cloud

--- a/src/spaceone/inventory/metrics/CloudRun/Configuration/namespace.yaml
+++ b/src/spaceone/inventory/metrics/CloudRun/Configuration/namespace.yaml
@@ -3,6 +3,6 @@ namespace_id: ns-google-cloud-cloudrun-configuration
 name: CloudRun/Configuration
 category: ASSET
 icon: 'https://spaceone-custom-assets.s3.ap-northeast-2.amazonaws.com/console-assets/icons/cloud-services/google_cloud/Cloud-Run.svg'
-version: '1.1'
+version: '1.2'
 resource_type: inventory.CloudService:google_cloud.CloudRun.Configuration
 group: google_cloud

--- a/src/spaceone/inventory/metrics/CloudRun/DomainMapping/namespace.yaml
+++ b/src/spaceone/inventory/metrics/CloudRun/DomainMapping/namespace.yaml
@@ -3,6 +3,6 @@ namespace_id: ns-google-cloud-cloudrun-domain_mapping
 name: CloudRun/DomainMapping
 category: ASSET
 icon: 'https://spaceone-custom-assets.s3.ap-northeast-2.amazonaws.com/console-assets/icons/cloud-services/google_cloud/Cloud-Run.svg'
-version: '1.1'
+version: '1.2'
 resource_type: inventory.CloudService:google_cloud.CloudRun.DomainMapping
 group: google_cloud

--- a/src/spaceone/inventory/metrics/CloudRun/Job/namespace.yaml
+++ b/src/spaceone/inventory/metrics/CloudRun/Job/namespace.yaml
@@ -3,6 +3,6 @@ namespace_id: ns-google-cloud-cloudrun-job
 name: CloudRun/Job
 category: ASSET
 icon: 'https://spaceone-custom-assets.s3.ap-northeast-2.amazonaws.com/console-assets/icons/cloud-services/google_cloud/Cloud-Run.svg'
-version: '1.1'
+version: '1.2'
 resource_type: inventory.CloudService:google_cloud.CloudRun.Job
 group: google_cloud

--- a/src/spaceone/inventory/metrics/CloudRun/Operation/namespace.yaml
+++ b/src/spaceone/inventory/metrics/CloudRun/Operation/namespace.yaml
@@ -3,6 +3,6 @@ namespace_id: ns-google-cloud-cloudrun-operation
 name: CloudRun/Operation
 category: ASSET
 icon: 'https://spaceone-custom-assets.s3.ap-northeast-2.amazonaws.com/console-assets/icons/cloud-services/google_cloud/Cloud-Run.svg'
-version: '1.1'
+version: '1.2'
 resource_type: inventory.CloudService:google_cloud.CloudRun.Operation
 group: google_cloud

--- a/src/spaceone/inventory/metrics/CloudRun/Route/namespace.yaml
+++ b/src/spaceone/inventory/metrics/CloudRun/Route/namespace.yaml
@@ -3,6 +3,6 @@ namespace_id: ns-google-cloud-cloudrun-route
 name: CloudRun/Route
 category: ASSET
 icon: 'https://spaceone-custom-assets.s3.ap-northeast-2.amazonaws.com/console-assets/icons/cloud-services/google_cloud/Cloud-Run.svg'
-version: '1.1'
+version: '1.2'
 resource_type: inventory.CloudService:google_cloud.CloudRun.Route
 group: google_cloud

--- a/src/spaceone/inventory/metrics/CloudRun/Service/namespace.yaml
+++ b/src/spaceone/inventory/metrics/CloudRun/Service/namespace.yaml
@@ -3,6 +3,6 @@ namespace_id: ns-google-cloud-cloudrun-service
 name: CloudRun/Service
 category: ASSET
 icon: 'https://spaceone-custom-assets.s3.ap-northeast-2.amazonaws.com/console-assets/icons/cloud-services/google_cloud/Cloud-Run.svg'
-version: '1.1'
+version: '1.2'
 resource_type: inventory.CloudService:google_cloud.CloudRun.Service
 group: google_cloud

--- a/src/spaceone/inventory/metrics/CloudRun/WorkerPool/namespace.yaml
+++ b/src/spaceone/inventory/metrics/CloudRun/WorkerPool/namespace.yaml
@@ -3,6 +3,6 @@ namespace_id: ns-google-cloud-cloudrun-worker_pool
 name: CloudRun/WorkerPool
 category: ASSET
 icon: 'https://spaceone-custom-assets.s3.ap-northeast-2.amazonaws.com/console-assets/icons/cloud-services/google_cloud/Cloud-Run.svg'
-version: '1.1'
+version: '1.2'
 resource_type: inventory.CloudService:google_cloud.CloudRun.WorkerPool
 group: google_cloud

--- a/src/spaceone/inventory/metrics/ComputeEngine/InstanceTemplate/namespace.yaml
+++ b/src/spaceone/inventory/metrics/ComputeEngine/InstanceTemplate/namespace.yaml
@@ -3,6 +3,6 @@ namespace_id: ns-google-cloud-ce-instance-template
 name: ComputeEngine/InstanceTemplate
 category: ASSET
 icon: 'https://spaceone-custom-assets.s3.ap-northeast-2.amazonaws.com/console-assets/icons/cloud-services/google_cloud/Compute_Engine.svg'
-version: '1.1'
+version: '1.2'
 resource_type: inventory.CloudService:google_cloud.ComputeEngine.InstanceTemplate
 group: google_cloud


### PR DESCRIPTION
✦ Chore-Metrics-GCP-INVEN-003-Bump-Namespace-Versions

   - What: Incremented the version field from '1.1' to '1.2' across all metric namespace.yaml files.
   - Why: To reflect an update or new revision of the metric namespace definitions.
   - Impact: Updates the version identifier for metric namespaces. This is a metadata change and has no direct impact on data collection logic.